### PR TITLE
Update ifconfig.co example endpoint

### DIFF
--- a/src/example.config.py
+++ b/src/example.config.py
@@ -36,7 +36,7 @@ run your own external IP provider:
 + <?php $ip = $_SERVER['REMOTE_ADDR']; ?>
   <?php print $ip; ?>
 e.g. 
-+ https://ifconfig.co
++ https://ifconfig.co/ip
 + http://ifconfig.me/ip
 + http://whatismyip.akamai.com/
 + http://ipinfo.io/ip


### PR DESCRIPTION
Requesting the url without `/ip` will return a response with the HTML of the web page, causing the script to throw an error