### PR TITLE
Add snap support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 src/config.py
 src/config.pyc
+parts
+prime
+snap/.snapcraft
+stage
+*.snap

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -e
+
+# CONFIG FILE PATH
+CONFIG_FILE=$SNAP_DATA/config
+
+# CONFIG OPTIONS: username, port, something-else
+OPTIONS="apisecret apiendpoint domain subdomains ttl ifconfig"
+
+## add or replace an option inside the config file. Create the file if doesn't exist
+refresh_opt_in_config() {
+    opt=$1
+    value="$2"
+    replace_line="$opt=$value"
+    if [ ! -e $CONFIG_FILE ]; then
+        echo "[settings]" > $CONFIG_FILE
+    fi
+    if $(grep -q "$opt=" $CONFIG_FILE 2> /dev/null); then
+        sed "s/^$opt=.*/$replace_line/" $CONFIG_FILE 2>/dev/null >${CONFIG_FILE}.new
+        mv -f ${CONFIG_FILE}.new $CONFIG_FILE 2>/dev/null
+    else
+        echo $replace_line >> $CONFIG_FILE
+    fi
+}
+
+# Iterate through the config options array
+for opt in $OPTIONS
+    do
+    # Use snapctl to get the value registered by the snap set command
+    echo "Configuration changed '$opt': $(snapctl get $opt)"
+    refresh_opt_in_config $opt $(snapctl get $opt)
+done
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,7 +12,7 @@ description: |
   With the new v5 Website, Gandi has also launched a new REST API which makes it
   easier to communicate via bash/curl or python/requests.
 
-grade: devel
+grade: stable
 confinement: strict
 
 parts:
@@ -24,14 +24,13 @@ parts:
       - python-args
       - python-simplejson
     override-build: |
-      mkdir -p $SNAPCRAFT_PART_INSTALL/bin
-      cp -v src/example.config.py src/config.py
+      cp -v src/snap.config.py src/config.py
       mv -v src/gandi-live-dns.py \
             src/config.py \
-            $SNAPCRAFT_PART_INSTALL/bin
+            $SNAPCRAFT_PART_INSTALL
       snapcraftctl build
 
 apps:
   gandi-live-dns:
-    command: python $SNAP/bin/gandi-live-dns.py
+    command: python $SNAP/gandi-live-dns.py
     plugs: [network]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,37 @@
+name: gandi-live-dns
+version: git
+summary: GANDI dynamic DNS updater
+description: |
+  This is a simple dynamic DNS updater for the Gandi registrar. It uses their
+  LiveDNS REST API to update the zone file for a subdomain of a domain to point
+  at the external IPv4 address of the computer it has been run from.
+
+  It has been developed on Debian 8 Jessie and tested on Debian 9 Stretch
+  GNU/Linux using Python 2.7.
+
+  With the new v5 Website, Gandi has also launched a new REST API which makes it
+  easier to communicate via bash/curl or python/requests.
+
+grade: devel
+confinement: strict
+
+parts:
+  gandi-live-dns:
+    plugin: nil
+    stage-packages:
+      - unzip
+      - python-requests
+      - python-args
+      - python-simplejson
+    override-build: |
+      mkdir -p $SNAPCRAFT_PART_INSTALL/bin
+      cp -v src/example.config.py src/config.py
+      mv -v src/gandi-live-dns.py \
+            src/config.py \
+            $SNAPCRAFT_PART_INSTALL/bin
+      snapcraftctl build
+
+apps:
+  gandi-live-dns:
+    command: python $SNAP/bin/gandi-live-dns.py
+    plugs: [network]

--- a/src/snap.config.py
+++ b/src/snap.config.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+import ConfigParser
+from ConfigParser import NoOptionError
+import os
+
+snap = os.environ['SNAP_NAME']
+config_file = os.path.join(os.environ['SNAP_DATA'], 'config')
+
+def error_msg(key):
+    return ("No `{key}` value set, you need to configure this snap using " \
+        "`snap set {snap} {key}=<value>`".format(key=key, snap=snap))
+
+if not os.path.exists(config_file):
+    raise Exception("No configuration file found at {}".format(config_file))
+
+try:
+    config = ConfigParser.ConfigParser()
+    config.readfp(open(config_file))
+except:
+    raise Exception("Impossible to open config file {}".format(config_file))
+
+def get_setting(key):
+    try:
+        s = config.get('settings', key)
+        if not len(s):
+            raise NoOptionError('settings', key)
+    except NoOptionError as e:
+        raise e
+    return s
+
+try:
+    api_secret = get_setting('apisecret')
+except NoOptionError as e:
+    print(error_msg("apisecret"))
+    print('''
+    Get your API key
+    Start by retrieving your API Key from the "Security" section in new Account admin panel to be able to make authenticated requests to the API.
+    https://account.gandi.net/
+    ''')
+    raise e
+
+try:
+    api_endpoint = get_setting('apiendpoint')
+except NoOptionError as e:
+    api_endpoint = 'https://dns.api.gandi.net/api/v5'
+
+try:
+    domain = config.get("settings", "domain")
+except NoOptionError as e:
+    print(error_msg("domain"))
+    raise e
+
+try:
+    subdomains = get_setting('subdomains').split(',')
+except NoOptionError as e:
+    subdomains = ''
+
+try:
+    ttl = get_setting('ttl')
+except NoOptionError as e:
+    ttl = '300'
+
+try:
+    ifconfig = get_setting('ifconfig')
+except NoOptionError as e:
+    ifconfig = 'http://ipv4.myexternalip.com/raw'


### PR DESCRIPTION
Build [snap package](http://snapcraft.io/) for this tool with configuration support.

[Soon](https://forum.snapcraft.io/t/add-support-for-service-timers/1068/) it could also be configured to automatically with a timer.

Currently I've registered the name in the snap store, but I can pass you the owrnership, while you can setup auto-builds for last revisions using [build.snapcraft.io](https://build.snapcraft.io/)