### PR TITLE
Port to new API endpoints, revamp output and remove api_endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,6 @@ Edit the config file to fit your needs.
 Start by retrieving your API Key from the "Security" section in new [Gandi Account admin panel](https://account.gandi.net/) to be able to make authenticated requests to the API.
 api_secret = '---my_secret_API_KEY----'
 
-##### api_endpoint
-Gandiv5 LiveDNS API Location
-http://doc.livedns.gandi.net/#api-endpoint
-
-```
-api_endpoint = 'https://dns.api.gandi.net/api/v5'
-```
-
 ##### domain
 Your domain for the subdomains to be updated 
 
@@ -66,9 +58,8 @@ And run the script:
 
 ```
 root@dyndns:~/gandi-live-dns-master/src# ./gandi-live-dns.py   
-Checking dynamic IP:  127.0.0.1
-Checking IP from DNS Record subdomain1:  127.0.0.1
-IP Address Match - no further action
+Checking dynamic IP: 127.0.0.1
+[subdomain1] IP Address Match - no further action
 ```
 
 If your IP has changed, it will be detected and the update will be triggered. 
@@ -76,12 +67,9 @@ If your IP has changed, it will be detected and the update will be triggered.
 
 ```
 root@dyndns:~/gandi-live-dns-master/src# ./gandi-live-dns.py
-Checking dynamic IP:  127.0.0.2
-Checking IP from DNS Record subdomain1:  127.0.0.1
-IP Address Mismatch - going to update the DNS Records for the subdomains with new IP 127.0.0.2
-Status Code: 201 , DNS Record Created , IP updated for subdomain1
-Status Code: 201 , DNS Record Created , IP updated for subdomain2
-Status Code: 201 , DNS Record Created , IP updated for subdomain3
+Checking dynamic IP: 127.0.0.2
+[subdomain1] IP Address Mismatch - updating 127.0.0.1 to 127.0.0.2
+[subdomain1] IP updated, status code: 201: DNS Record Created
 ```
 
 #### Command Line Arguments

--- a/src/example.config.py
+++ b/src/example.config.py
@@ -13,13 +13,6 @@ https://account.gandi.net/
 '''
 api_secret = '---my_secret_API_KEY----'
 
-'''
-Gandiv5 LiveDNS API Location
-http://doc.livedns.gandi.net/#api-endpoint
-https://dns.api.gandi.net/api/v5/
-'''
-api_endpoint = 'https://dns.api.gandi.net/api/v5'
-
 #your domain with the subdomains in the zone file/UUID 
 domain = 'mydomain.tld'
 

--- a/src/gandi-live-dns.py
+++ b/src/gandi-live-dns.py
@@ -16,103 +16,58 @@ import requests, json
 import config
 import argparse
 
+api_endpoint = 'https://api.gandi.net/v5/livedns/domains/'
+
+headers = {"Content-Type": "application/json", "Authorization": "Apikey " + config.api_secret}
 
 def get_dynip(ifconfig_provider):
     ''' find out own IPv4 at home <-- this is the dynamic IP which changes more or less frequently
     similar to curl ifconfig.me/ip, see example.config.py for details to ifconfig providers 
     ''' 
     r = requests.get(ifconfig_provider)
-    print 'Checking dynamic IP: ' , r._content.strip('\n')
+    print 'Checking dynamic IP:', r._content.strip('\n')
     return r.content.strip('\n')
 
-def get_uuid():
-    ''' 
-    find out ZONE UUID from domain
-    Info on domain "DOMAIN"
-    GET /domains/<DOMAIN>:
-        
-    '''
-    url = config.api_endpoint + '/domains/' + config.domain
-    u = requests.get(url, headers={"X-Api-Key":config.api_secret})
+def get_dnsip(subdomain):
+    '''Finds A record for subdomain'''
+    url = api_endpoint + config.domain + "/records/" + subdomain
+
+    u = requests.get(url + "/A", headers=headers)
     json_object = json.loads(u._content)
     if u.status_code == 200:
-        return json_object['zone_uuid']
-    else:
-        print 'Error: HTTP Status Code ', u.status_code, 'when trying to get Zone UUID'
-        print  json_object['message']
-        exit()
-
-def get_dnsip(uuid):
-    ''' find out IP from first Subdomain DNS-Record
-    List all records with name "NAME" and type "TYPE" in the zone UUID
-    GET /zones/<UUID>/records/<NAME>/<TYPE>:
-    
-    The first subdomain from config.subdomain will be used to get   
-    the actual DNS Record IP
-    '''
-
-    url = config.api_endpoint+ '/zones/' + uuid + '/records/' + config.subdomains[0] + '/A'
-    headers = {"X-Api-Key":config.api_secret}
-    u = requests.get(url, headers=headers)
-    if u.status_code == 200:
-        json_object = json.loads(u._content)
-        print 'Checking IP from DNS Record' , config.subdomains[0], ':', json_object['rrset_values'][0].encode('ascii','ignore').strip('\n')
         return json_object['rrset_values'][0].encode('ascii','ignore').strip('\n')
     else:
-        print 'Error: HTTP Status Code ', u.status_code, 'when trying to get IP from subdomain', config.subdomains[0]   
-        print  json_object['message']
+        print '[%s] Error: HTTP Status Code %s when trying to get IP' % (subdomain, u.status_code)
+        print json_object['message']
         exit()
 
-def update_records(uuid, dynIP, subdomain):
-    ''' update DNS Records for Subdomains 
-        Change the "NAME"/"TYPE" record from the zone UUID
-        PUT /zones/<UUID>/records/<NAME>/<TYPE>:
-        curl -X PUT -H "Content-Type: application/json" \
-                    -H 'X-Api-Key: XXX' \
-                    -d '{"rrset_ttl": 10800,
-                         "rrset_values": ["<VALUE>"]}' \
-                    https://dns.gandi.net/api/v5/zones/<UUID>/records/<NAME>/<TYPE>
-    '''
-    url = config.api_endpoint+ '/zones/' + uuid + '/records/' + subdomain + '/A'
-    payload = {"rrset_ttl": config.ttl, "rrset_values": [dynIP]}
-    headers = {"Content-Type": "application/json", "X-Api-Key":config.api_secret}
+def update_records(dynIP, subdomain):
+    '''Update DNS Records for a subdomain'''
+    payload = {"items": [{"rrset_ttl": config.ttl, "rrset_values": [dynIP], "rrset_type": "A"}]}
+    url = api_endpoint + config.domain + "/records/" + subdomain
     u = requests.put(url, data=json.dumps(payload), headers=headers)
     json_object = json.loads(u._content)
-
     if u.status_code == 201:
-        print 'Status Code:', u.status_code, ',', json_object['message'], ', IP updated for', subdomain
+        print '[%s] IP updated, status code: %s: %s' % (subdomain, u.status_code, json_object['message'])
         return True
     else:
-        print 'Error: HTTP Status Code ', u.status_code, 'when trying to update IP from subdomain', subdomain   
-        print  json_object['message']
+        print '[%s] Error when updating IP, status code: %s: %s' % (subdomain, u.status_code, json_object['message'])
         exit()
-
-
 
 def main(force_update, verbosity):
 
     if verbosity:
         print "verbosity turned on - not implemented by now"
-
         
-    #get zone ID from Account
-    uuid = get_uuid()
-   
     #compare dynIP and DNS IP 
     dynIP = get_dynip(config.ifconfig)
-    dnsIP = get_dnsip(uuid)
-    
-    if force_update:
-        print "Going to update/create the DNS Records for the subdomains"
-        for sub in config.subdomains:
-            update_records(uuid, dynIP, sub)
-    else:
+    for subdomain in config.subdomains:
+        dnsIP = get_dnsip(subdomain)
         if dynIP == dnsIP:
-            print "IP Address Match - no further action"
+            print "[%s] IP Address Match - no further action" % subdomain
         else:
-            print "IP Address Mismatch - going to update the DNS Records for the subdomains with new IP", dynIP
-            for sub in config.subdomains:
-                update_records(uuid, dynIP, sub)
+            print "[%s] IP Address Mismatch - updating %s to %s" % (subdomain, dnsIP, dynIP)
+            update_records(dynIP, subdomain)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -122,9 +77,3 @@ if __name__ == "__main__":
         
         
     main(args.force, args.verbose)
-
-
-
-
-
-    


### PR DESCRIPTION
Gandi declared https://dns.api.gandi.net end-of-life. The new API
endpoints are at api.gandi.net/v5/livedns as documented at
https://api.gandi.net/docs/livedns/.

We remove the api_endpoint from the configuration file, as this is not
really a user configurable option. We also modernize the output a bit.